### PR TITLE
Added HTTP basic auth support for httpget

### DIFF
--- a/src/main/java/burp/SigHttpCredentialProvider.java
+++ b/src/main/java/burp/SigHttpCredentialProvider.java
@@ -73,10 +73,21 @@ public class SigHttpCredentialProvider implements SigCredentialProvider
         SigCredential newCredential = null;
         byte[] response;
         try {
+            byte[] request = helpers.buildHttpRequest(requestUri.toURL());
+            // If the configured URL includes username and password,
+            // they will be used when fetching credentials.
+            if (requestUri.getUserInfo() != ""){
+                IRequestInfo rqInfo = helpers.analyzeRequest(request);
+                java.util.List<java.lang.String> headers = rqInfo.getHeaders();
+                headers.add("Authorization: Basic " + helpers.base64Encode(requestUri.getUserInfo()));
+                String tempReq = new String(request);
+                String messageBody = tempReq.substring(rqInfo.getBodyOffset());
+                request = helpers.buildHttpMessage(headers, messageBody.getBytes());
+            }
             response = callbacks.makeHttpRequest(requestUri.getHost(),
                     requestUri.getPort(),
                     requestUri.getScheme().equalsIgnoreCase("https"),
-                    helpers.buildHttpRequest(requestUri.toURL()));
+                    request);
         } catch (MalformedURLException | IllegalArgumentException e) {
             throw new IllegalArgumentException("Invalid URL for HttpGet: "+requestUri);
         }


### PR DESCRIPTION
I implemented a service that provides AWS credentials via HTTP to updated expired tokens. However, I would prefer to at least have HTTP basic authentication on this service. With this change you don't have to change anything in the UI.

It should be noted that this might not be the ideal implementation, I just hacked it together to make it work. Feel free to propose any other solution that accomplishes the same.