### PR TITLE
Content Menu Item for JSON Credential Import

### DIFF
--- a/src/main/java/burp/BurpExtender.java
+++ b/src/main/java/burp/BurpExtender.java
@@ -935,32 +935,35 @@ public class BurpExtender implements IBurpExtender, IHttpListener, ITab, IExtens
                     });
                     list.add(editSignatureItem);
                 }
+                break;
             case IContextMenuInvocation.CONTEXT_MESSAGE_VIEWER_RESPONSE:
+                final IHttpRequestResponse[] selectedMessages = invocation.getSelectedMessages();
+                if (selectedMessages == null || selectedMessages.length < 1) {
+                    break;
+                }
                 final int[] bounds = invocation.getSelectionBounds();
-                if (invocation.getSelectedMessages().length > 0 && (bounds != null) && (bounds[1] - bounds[0] < 90)) {
+                if (bounds == null || (bounds[1] - bounds[0] < 90)) {
                     // expect at least 90 chars for API credentials with a key id and secret.
                     break;
                 }
                 JMenuItem importItem = new JMenuItem("Import Selected Credential");
                 importItem.addActionListener(actionEvent -> {
-                    IHttpRequestResponse[] selectedMessages = invocation.getSelectedMessages();
-                    if (selectedMessages.length > 0 && (bounds != null) && (bounds[1] - bounds[0] > 90)) {
-                        final byte[] selection = Arrays.copyOfRange(selectedMessages[0].getResponse(), bounds[0], bounds[1]);
-                        try {
-                            Optional<SigProfile> profile = JSONCredentialParser.profileFromJSON(new String(selection));
-                            if (profile.isPresent()) {
-                                SigProfileEditorDialog dialog = new SigProfileEditorDialog(null, "Import Credential", true, null);
-                                dialog.applyProfile(profile.get());
-                                dialog.setVisible(true);
-                            } else {
-                                logger.error("Invalid JSON credentials object");
-                            }
-                        } catch (JsonSyntaxException e) {
+                    final byte[] selection = Arrays.copyOfRange(selectedMessages[0].getResponse(), bounds[0], bounds[1]);
+                    try {
+                        Optional<SigProfile> profile = JSONCredentialParser.profileFromJSON(new String(selection));
+                        if (profile.isPresent()) {
+                            SigProfileEditorDialog dialog = new SigProfileEditorDialog(null, "Import Credential", true, null);
+                            dialog.applyProfile(profile.get());
+                            dialog.setVisible(true);
+                        } else {
                             logger.error("Invalid JSON credentials object");
                         }
+                    } catch (JsonSyntaxException e) {
+                        logger.error("Invalid JSON credentials object");
                     }
                 });
                 list.add(importItem);
+                break;
         }
         return list;
     }

--- a/src/main/java/burp/JSONCredentialParser.java
+++ b/src/main/java/burp/JSONCredentialParser.java
@@ -64,14 +64,12 @@ public class JSONCredentialParser {
         // Try to parse as Cognito.
         // See https://docs.aws.amazon.com/cognitoidentity/latest/APIReference/API_GetCredentialsForIdentity.html#API_GetCredentialsForIdentity_ResponseSyntax
         try {
-
             JsonObject jsonObject = new Gson().fromJson(jsonText, JsonObject.class);
             // If this is from Cognito, we may have an IdentityId to use as the profile name.
             String profileName = null;
             if (jsonObject.get("IdentityId") != null) {
                 profileName = jsonObject.get("IdentityId").getAsString();
             }
-            // Cognito wraps
             if (jsonObject.get("Credentials") != null) {
                 jsonObject = jsonObject.get("Credentials").getAsJsonObject();
             }

--- a/src/main/java/burp/JSONCredentialParser.java
+++ b/src/main/java/burp/JSONCredentialParser.java
@@ -1,0 +1,116 @@
+package burp;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSyntaxException;
+
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+public class JSONCredentialParser {
+    protected static LogWriter logger = LogWriter.getLogger();
+
+    public static Optional<SigProfile> profileFromJSON(final String jsonText) {
+        Optional<SigProfile> profile = profileFromCognitoJSON(jsonText);
+        if (profile.isPresent()) {
+            return profile;
+        }
+        return profileFromAssumeRoleJSON(jsonText);
+    }
+
+    private static long expirationTimeToEpochSeconds(final String expiry) {
+        try {
+            return Long.parseLong(expiry);
+        } catch (NumberFormatException ignored) {
+        }
+        try {
+            return Instant.from(DateTimeFormatter.ISO_INSTANT.parse(expiry)).getEpochSecond();
+        } catch (DateTimeException ignored) {
+        }
+        throw new IllegalArgumentException("Failed to parse expiration timestamp");
+    }
+
+    public static Optional<SigProfile> profileFromAssumeRoleJSON(final String jsonText) {
+        try {
+            JsonObject jsonObject = new Gson().fromJson(jsonText, JsonObject.class);
+            SigCredential staticCredential;
+            if (jsonObject.has("SessionToken")) {
+                staticCredential = new SigTemporaryCredential(
+                        jsonObject.get("AccessKeyId").getAsString(),
+                        jsonObject.get("SecretAccessKey").getAsString(),
+                        jsonObject.get("SessionToken").getAsString(),
+                        expirationTimeToEpochSeconds(jsonObject.get("Expiration").getAsString()));
+            } else {
+                staticCredential = new SigStaticCredential(
+                        jsonObject.get("AccessKeyId").getAsString(),
+                        jsonObject.get("SecretAccessKey").getAsString());
+            }
+            SigProfile profile = new SigProfile.Builder(jsonObject.get("AccessKeyId").getAsString()).
+                    withCredentialProvider(
+                            new SigStaticCredentialProvider(staticCredential),
+                            SigProfile.DEFAULT_STATIC_PRIORITY).
+                    build();
+            return Optional.of(profile);
+        } catch (JsonParseException | NullPointerException | IllegalArgumentException exc) {
+            logger.error("Not a valid STS JSON credentials object");
+        }
+        return Optional.empty();
+    }
+
+    public static Optional<SigProfile> profileFromCognitoJSON(final String jsonText) {
+        // Try to parse as Cognito.
+        // See https://docs.aws.amazon.com/cognitoidentity/latest/APIReference/API_GetCredentialsForIdentity.html#API_GetCredentialsForIdentity_ResponseSyntax
+        try {
+
+            JsonObject jsonObject = new Gson().fromJson(jsonText, JsonObject.class);
+            // If this is from Cognito, we may have an IdentityId to use as the profile name.
+            String profileName = null;
+            if (jsonObject.get("IdentityId") != null) {
+                profileName = jsonObject.get("IdentityId").getAsString();
+            }
+            // Cognito wraps
+            if (jsonObject.get("Credentials") != null) {
+                jsonObject = jsonObject.get("Credentials").getAsJsonObject();
+            }
+            if (jsonObject.get("AccessKeyId") == null || jsonObject.get("SecretKey") == null) {
+                logger.error("Invalid JSON credentials object. AccessKeyId and SecretKey are required.");
+                return Optional.empty();
+            }
+            if (profileName == null) {
+                profileName = jsonObject.get("AccessKeyId").getAsString();
+            }
+            SigCredential staticCredential;
+            if (jsonObject.get("SessionToken") != null) {
+                long expiration = (System.currentTimeMillis() / 1000) + 43200;
+                if (jsonObject.get("Expiration") != null) {
+                    try {
+                        expiration = jsonObject.get("Expiration").getAsLong();
+                    } catch (ClassCastException | NumberFormatException e) {
+                        logger.error("Invalid Expiration. Expected an integer.");
+                    }
+                }
+                staticCredential = new SigTemporaryCredential(
+                        jsonObject.get("AccessKeyId").getAsString(),
+                        jsonObject.get("SecretKey").getAsString(),
+                        jsonObject.get("SessionToken").getAsString(),
+                        expiration);
+            } else {
+                staticCredential = new SigStaticCredential(
+                        jsonObject.get("AccessKeyId").getAsString(),
+                        jsonObject.get("SecretKey").getAsString());
+            }
+            SigProfile profile = new SigProfile.Builder(profileName).
+                    withCredentialProvider(
+                            new SigStaticCredentialProvider(staticCredential),
+                            SigProfile.DEFAULT_STATIC_PRIORITY).
+                    build();
+            return Optional.of(profile);
+        } catch (JsonSyntaxException e) {
+            logger.error("Not a valid Cognito JSON credentials object");
+        }
+        return Optional.empty();
+    }
+}


### PR DESCRIPTION
This PR adds a new item to the context menu for responses. The "Import Selected Credential" item will appear under Extensions -> SigV4 when a JSON object is selected in a response. If the JSON is a valid API credential in Cognito or STS AssumeRole format, a profile editor dialog will appear.

This is in response to issue https://github.com/anvilsecure/aws-sigv4/issues/12