### PR TITLE
Auto Import Session Token Amendment

### DIFF
--- a/src/main/java/burp/ConfigParser.java
+++ b/src/main/java/burp/ConfigParser.java
@@ -16,7 +16,7 @@ see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html
 public class ConfigParser
 {
     private static final Pattern sectionPattern = Pattern.compile("^\\s*\\[\\s*([^]]{1,256}?)\\s*\\]\\s*$");
-    private static final Pattern valuePattern = Pattern.compile("^\\s*([^=]{1,256}?)\\s*=\\s*(.{1,256}?)\\s*$");
+    private static final Pattern valuePattern = Pattern.compile("^\\s*([^=]{1,256}?)\\s*=\\s*(.{1,740}?)\\s*$");
 
     public static Map<String, Map<String, String>> parse(final Path path)
     {

--- a/src/main/java/burp/ConfigParser.java
+++ b/src/main/java/burp/ConfigParser.java
@@ -16,7 +16,7 @@ see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html
 public class ConfigParser
 {
     private static final Pattern sectionPattern = Pattern.compile("^\\s*\\[\\s*([^]]{1,256}?)\\s*\\]\\s*$");
-    private static final Pattern valuePattern = Pattern.compile("^\\s*([^=]{1,256}?)\\s*=\\s*(.{1,740}?)\\s*$");
+    private static final Pattern valuePattern = Pattern.compile("^\\s*([^=]{1,256}?)\\s*=\\s*(.{1,760}?)\\s*$");
 
     public static Map<String, Map<String, String>> parse(final Path path)
     {


### PR DESCRIPTION
Updated the "value" pattern in [src/main/java/burp/ConfigParser.java#19](https://github.com/anvilsecure/aws-sigv4/blob/667aa88b1463a114b9e161cc45721951dce456a9/src/main/java/burp/ConfigParser.java#L19) for session tokens which are longer than 256 characters.

In my current use case, the session token is 736 characters long, which will fail to populate the corresponding field when using the auto import feature. With the updated pattern, the session token is correctly parsed and added to the profile.

![image](https://user-images.githubusercontent.com/66413174/201220990-e99704c5-8e94-4514-a701-4654ae604919.png)

Addresses issue #17.
