### PR TITLE
Prompt user when their specified profile is not found

### DIFF
--- a/src/main/java/burp/SigMessageEditorTab.java
+++ b/src/main/java/burp/SigMessageEditorTab.java
@@ -56,7 +56,16 @@ public class SigMessageEditorTab implements IMessageEditorTab
             }
 
             this.content = content;
-            final SigProfile profile = this.burp.getSigningProfile(requestInfo.getHeaders());
+
+            SigProfile nonFinalProfile = null;
+            try {
+                nonFinalProfile = this.burp.getSigningProfile(requestInfo.getHeaders());
+            } catch (UserSpecifiedSigningProfileNotFoundException e) {
+                // Keep value as null
+                nonFinalProfile = null;
+            }
+            final SigProfile profile = nonFinalProfile;
+
             this.messageTextEditor.setText(this.burp.helpers.stringToBytes("Signing request..."));
 
             // thread this to prevent blocking the UI thread. signRequest can trigger an http request if temp credentials are configured.

--- a/src/main/java/burp/UserSpecifiedSigningProfileNotFoundException.java
+++ b/src/main/java/burp/UserSpecifiedSigningProfileNotFoundException.java
@@ -1,0 +1,4 @@
+package burp;
+
+class UserSpecifiedSigningProfileNotFoundException extends Exception {}
+


### PR DESCRIPTION
If a user specified as profile in the 'X-BurpSigV4-Profile' header, and that profile is not found, prompt the user with a message